### PR TITLE
Minor improvements to SBDebugger's interface

### DIFF
--- a/SwiftLLDB/SBDebugger.h
+++ b/SwiftLLDB/SBDebugger.h
@@ -12,17 +12,15 @@ typedef NS_ENUM(NSUInteger, LanguageType) {
 };
 
 @interface SBDebugger : NSObject
-- (nonnull id) init;
 
-- (void) setAsync: (BOOL)async;
-- (BOOL) getAsync;
+@property (nonatomic, getter=isAsync) BOOL async;
 
-- (BOOL) setInputFileHandle: (nonnull NSFileHandle *)fileHandle error:(NSError **)error;
-- (BOOL) setOutputFileHandle: (nonnull NSFileHandle *)fileHandle error:(NSError **)error;
-- (BOOL) setErrorFileHanlde: (nonnull NSFileHandle *)fileHandle error:(NSError **)error;
+- (BOOL) setInputFileHandle: (NSFileHandle *)fileHandle error:(NSError **)error;
+- (BOOL) setOutputFileHandle: (NSFileHandle *)fileHandle error:(NSError **)error;
+- (BOOL) setErrorFileHandle: (NSFileHandle *)fileHandle error:(NSError **)error;
 
 - (void) runCommandInterpreter: (BOOL)autoHandleEvents spawnThread:(BOOL)spawnThread;
-- (BOOL) runREPL: (LanguageType)languageType options:(nonnull NSString *)replOptions error:(NSError **)error;
+- (BOOL) runREPL: (LanguageType)languageType options:(NSString *)replOptions error:(NSError **)error;
 
 + (void) setUp;
 + (void) tearDown;

--- a/SwiftLLDB/SBDebugger.mm
+++ b/SwiftLLDB/SBDebugger.mm
@@ -24,7 +24,7 @@
     debugger.SetAsync(async);
 }
 
-- (BOOL) getAsync {
+- (BOOL) isAsync {
     return debugger.GetAsync();
 }
 
@@ -67,7 +67,7 @@ FILE *dupFileHanle(NSFileHandle *fileHandle, const char *mode, NSError **error) 
     return YES;
 }
 
-- (BOOL) setErrorFileHanlde: (nonnull NSFileHandle *)fileHandle error:(NSError **)error {
+- (BOOL) setErrorFileHandle: (nonnull NSFileHandle *)fileHandle error:(NSError **)error {
     FILE *f = dupFileHanle(fileHandle, "w", error);
     if (!f) { return NO; }
     debugger.SetErrorFileHandle(f, /*transfer_ownership=*/true);


### PR DESCRIPTION
- Since `init` is defined on `NSObject` we don't have to explicitly include it here.
- Since we're using `NS_ASSUME_NONNULL_BEGIN/END` we don't need all the `nonnull` annotations.
- `setErrorFileHanlde` -> `setErrorFileHandle`
- The getter/setter pair for setting the `async` flag has been turned into a property.
